### PR TITLE
add GitHub Actions deploy workflow for WordPress.org

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,7 @@
+.claude
+.git
+.github
+.gitignore
+.playwright-mcp
+assets
+Readme.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to WordPress.org
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: Deploy to WordPress.org SVN
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          WORDPRESS_USERNAME: ${{ secrets.WORDPRESS_USERNAME }}
+          WORDPRESS_PASSWORD: ${{ secrets.WORDPRESS_PASSWORD }}
+          SLUG: admin-slug-column
+          ASSETS_DIR: assets


### PR DESCRIPTION
- Adds GitHub Actions workflow that automatically deploys to WordPress.org SVN on every push to master via 10up/action-wordpress-plugin-deploy
- Adds .distignore to keep dev-only files out of SVN trunk (Readme.md, .github/, assets/, .claude/, etc.)
- Banner and icon images in assets/ are synced to SVN /assets/ separately

## Deploy flow
{if working branch →} dev → master (on merge) → GitHub Action triggers → SVN trunk + assets updated