### PR TITLE
ver 2.0.0 bump, major refactor, CPT support, php 8

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,7 @@
+.claude
+.git
+.github
+.gitignore
+.playwright-mcp
+assets
+Readme.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to WordPress.org
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: Deploy to WordPress.org SVN
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          WORDPRESS_USERNAME: ${{ secrets.WORDPRESS_USERNAME }}
+          WORDPRESS_PASSWORD: ${{ secrets.WORDPRESS_PASSWORD }}
+          SLUG: admin-slug-column
+          ASSETS_DIR: assets

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 This is the working development repo for the Admin Slug Column WordPress plugin located here: https://wordpress.org/plugins/admin-slug-column/
 
-This plugin adds a column to wp-admin "All Posts" and "All Pages" views displaying the URL path and Slug for each one. This will also show the nested path if a page is a child post of a parent. If a post or page is not published we'll do our best to determine the url path and display that slightly greyed out for quick reference as it's technically not an official URL path or Slug yet. This should also work for custom post types of type page or post, and furthermore this should now, as of v1.6, also display Multibyte characters in slugs for non-latin languages too.
+This plugin adds a URL path column to the edit screens for all post types — posts, pages, and any custom post type including WooCommerce products. Child pages show the full nested path. For drafts, pending, and scheduled content the URL path is shown slightly greyed out since it isn't an official URL yet. Multibyte characters in slugs (non-latin languages) are fully supported.
 
 I initially built this out of necessity to quickly identify pages by their slug/path as sometimes the titles that clients used did't match up nicely with the URL slug on the front-end of the site; so here's a fast way to do that. Nothing fancy, just does what it does.
 

--- a/admin-slug-column.php
+++ b/admin-slug-column.php
@@ -11,8 +11,8 @@
  * @wordpress-plugin
  * Plugin Name:       Admin Slug Column
  * Plugin URI:        https://github.com/chuckreynolds/Admin-Slug-Column
- * Description:       Adds the post URL slug and page URL path to the admin columns on edit screens.
- * Version:           1.7.0
+ * Description:       Adds the URL path to the admin columns on all post type edit screens.
+ * Version:           2.0.0
  * Requires at least: 5.2
  * Requires PHP:      8.0
  * Author:            Chuck Reynolds
@@ -117,7 +117,8 @@ class WPAdminSlugColumn {
 
 		$post_draft_url_pre = str_replace( home_url(), '', $post_draft_url_array[0] );
 		// urldecode() not needed here; get_sample_permalink()[1] already handles multibyte decoding.
-		$post_slug = str_replace( [ '%pagename%', '%postname%' ], $post_draft_url_array[1], $post_draft_url_pre );
+		// preg_replace handles any CPT rewrite tag placeholder, not just %postname%/%pagename%.
+		$post_slug = preg_replace( '/%[^%]+%/', $post_draft_url_array[1], $post_draft_url_pre );
 		printf(
 			'<span style="color: #999;">%s</span>',
 			esc_html( $post_slug )

--- a/admin-slug-column.php
+++ b/admin-slug-column.php
@@ -14,7 +14,7 @@
  * Description:       Adds the post URL slug and page URL path to the admin columns on edit screens.
  * Version:           1.7.0
  * Requires at least: 5.2
- * Requires PHP:      7.4
+ * Requires PHP:      8.0
  * Author:            Chuck Reynolds
  * Author URI:        https://chuckreynolds.com
  * Text Domain:       admin-slug-column
@@ -97,46 +97,47 @@ class WPAdminSlugColumn {
 		}
 
 		if ( in_array( $post->post_status, [ 'draft', 'pending', 'future' ], true ) ) {
-			$this->display_draft_slug( $post_id );
+			$this->display_draft_slug( $post );
 		} else {
-			$this->display_published_slug( $post_id );
+			$this->display_published_slug( $post );
 		}
 	}
 
 	/**
 	 * Displays the slug for draft, pending, or future posts
 	 *
-	 * @param int $post_id Post ID.
+	 * @param WP_Post $post Post object.
 	 * @return void
 	 */
-	private function display_draft_slug( int $post_id ): void {
-		$post_draft_url_array = get_sample_permalink( $post_id );
+	private function display_draft_slug( WP_Post $post ): void {
+		$post_draft_url_array = get_sample_permalink( $post );
 		if ( ! is_array( $post_draft_url_array ) || count( $post_draft_url_array ) !== 2 ) {
 			return;
 		}
 
 		$post_draft_url_pre = str_replace( home_url(), '', $post_draft_url_array[0] );
+		// urldecode() not needed here; get_sample_permalink()[1] already handles multibyte decoding.
 		$post_slug = str_replace( [ '%pagename%', '%postname%' ], $post_draft_url_array[1], $post_draft_url_pre );
 		printf(
 			'<span style="color: #999;">%s</span>',
-			esc_html( wp_strip_all_tags( $post_slug ) )
+			esc_html( $post_slug )
 		);
 	}
 
 	/**
 	 * Displays the slug for published posts
 	 *
-	 * @param int $post_id Post ID.
+	 * @param WP_Post $post Post object.
 	 * @return void
 	 */
-	private function display_published_slug( int $post_id ): void {
-		$permalink = get_permalink( $post_id );
+	private function display_published_slug( WP_Post $post ): void {
+		$permalink = get_permalink( $post );
 		if ( ! is_string( $permalink ) ) {
 			return;
 		}
 
 		$post_slug = str_replace( home_url(), '', $permalink );
-		echo esc_html( wp_strip_all_tags( urldecode( $post_slug ) ) );
+		echo esc_html( urldecode( $post_slug ) );
 	}
 }
 

--- a/admin-slug-column.php
+++ b/admin-slug-column.php
@@ -48,25 +48,35 @@ class WPAdminSlugColumn {
 	 * Initialize the plugin
 	 *
 	 * @param WP_Screen $current_screen The current screen object.
+	 * @return void
 	 */
-	public function init( $current_screen ) {
-		if ( ! $current_screen->base === 'edit' ) {
+	public function init( WP_Screen $current_screen ): void {
+		if ( 'edit' !== $current_screen->base ) {
 			return;
 		}
 
-		add_filter( "manage_{$current_screen->post_type}_posts_columns", [ $this, 'add_column' ] );
+		add_filter( "manage_{$current_screen->post_type}_posts_columns", [ $this, 'add_column' ], 10, 1 );
 		add_action( "manage_{$current_screen->post_type}_posts_custom_column", [ $this, 'display_column' ], 10, 2 );
 	}
 
 	/**
 	 * Adds Slug column to Posts list column
 	 *
-	 * @param array $columns An array of column names.
-	 * @return array Modified array of column names.
+	 * @param array<string, string> $columns An array of column names.
+	 * @return array<string, string> Modified array of column names.
 	 */
-	public function add_column( $columns ) {
-		$columns['wpasc-slug'] = __( 'URL Path', 'admin-slug-column' );
-		return $columns;
+	public function add_column( array $columns ): array {
+		$new_columns = [];
+		$insert_after = 'title';
+
+		foreach ( $columns as $key => $value ) {
+			$new_columns[ $key ] = $value;
+			if ( $key === $insert_after ) {
+				$new_columns['wpasc-slug'] = __( 'URL Path', 'admin-slug-column' );
+			}
+		}
+
+		return $new_columns;
 	}
 
 	/**
@@ -74,16 +84,19 @@ class WPAdminSlugColumn {
 	 *
 	 * @param string $column_name Name of the column.
 	 * @param int    $post_id     Post ID.
+	 * @return void
 	 */
-	public function display_column( $column_name, $post_id ) {
+	public function display_column( string $column_name, int $post_id ): void {
 		if ( 'wpasc-slug' !== $column_name ) {
 			return;
 		}
 
 		$post = get_post( $post_id );
-		$post_status = $post->post_status;
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
 
-		if ( in_array( $post_status, [ 'draft', 'pending', 'future' ], true ) ) {
+		if ( in_array( $post->post_status, [ 'draft', 'pending', 'future' ], true ) ) {
 			$this->display_draft_slug( $post_id );
 		} else {
 			$this->display_published_slug( $post_id );
@@ -94,23 +107,43 @@ class WPAdminSlugColumn {
 	 * Displays the slug for draft, pending, or future posts
 	 *
 	 * @param int $post_id Post ID.
+	 * @return void
 	 */
-	private function display_draft_slug( $post_id ) {
+	private function display_draft_slug( int $post_id ): void {
 		$post_draft_url_array = get_sample_permalink( $post_id );
+		if ( ! is_array( $post_draft_url_array ) || count( $post_draft_url_array ) !== 2 ) {
+			return;
+		}
+
 		$post_draft_url_pre = str_replace( home_url(), '', $post_draft_url_array[0] );
 		$post_slug = str_replace( [ '%pagename%', '%postname%' ], $post_draft_url_array[1], $post_draft_url_pre );
-		echo '<span style="color: #999;">' . esc_html( $post_slug ) . '</span>';
+		printf(
+			'<span style="color: #999;">%s</span>',
+			esc_html( wp_strip_all_tags( $post_slug ) )
+		);
 	}
 
 	/**
 	 * Displays the slug for published posts
 	 *
 	 * @param int $post_id Post ID.
+	 * @return void
 	 */
-	private function display_published_slug( $post_id ) {
-		$post_slug = str_replace( home_url(), '', get_permalink( $post_id ) );
-		echo esc_html( urldecode( $post_slug ) );
+	private function display_published_slug( int $post_id ): void {
+		$permalink = get_permalink( $post_id );
+		if ( ! is_string( $permalink ) ) {
+			return;
+		}
+
+		$post_slug = str_replace( home_url(), '', $permalink );
+		printf(
+			'%s',
+			esc_html( wp_strip_all_tags( urldecode( $post_slug ) ) )
+		);
 	}
 }
 
-new WPAdminSlugColumn();
+// Initialize the plugin
+add_action( 'plugins_loaded', function() {
+	new WPAdminSlugColumn();
+});

--- a/admin-slug-column.php
+++ b/admin-slug-column.php
@@ -12,17 +12,17 @@
  * Plugin Name:       Admin Slug Column
  * Plugin URI:        https://github.com/chuckreynolds/Admin-Slug-Column
  * Description:       Adds the post URL slug and page URL path to the admin columns on edit screens.
- * Version:           1.6.2
+ * Version:           1.7.0
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            Chuck Reynolds
  * Author URI:        https://chuckreynolds.com
  * Text Domain:       admin-slug-column
- * License:           GPL v2 or later
+ * License:           GPLv2 or later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-// If this file is called directly, abort
+// If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }

--- a/admin-slug-column.php
+++ b/admin-slug-column.php
@@ -136,14 +136,12 @@ class WPAdminSlugColumn {
 		}
 
 		$post_slug = str_replace( home_url(), '', $permalink );
-		printf(
-			'%s',
-			esc_html( wp_strip_all_tags( urldecode( $post_slug ) ) )
-		);
+		echo esc_html( wp_strip_all_tags( urldecode( $post_slug ) ) );
 	}
 }
 
 // Initialize the plugin
 add_action( 'plugins_loaded', function() {
 	new WPAdminSlugColumn();
-});
+} );
+

--- a/admin-slug-column.php
+++ b/admin-slug-column.php
@@ -11,10 +11,10 @@
  * @wordpress-plugin
  * Plugin Name:       Admin Slug Column
  * Plugin URI:        https://github.com/chuckreynolds/Admin-Slug-Column
- * Description:       Adds the post url slug and page url path to the admin columns on edit screens.
- * Version:           1.6.1
+ * Description:       Adds the post URL slug and page URL path to the admin columns on edit screens.
+ * Version:           1.6.2
  * Requires at least: 5.2
- * Requires PHP:      7.2
+ * Requires PHP:      7.4
  * Author:            Chuck Reynolds
  * Author URI:        https://chuckreynolds.com
  * Text Domain:       admin-slug-column
@@ -29,77 +29,88 @@ if ( ! defined( 'WPINC' ) ) {
 
 // Only run plugin in the admin
 if ( ! is_admin() ) {
-	return false;
+	return;
 }
 
-Class WPAdminSlugColumn {
+/**
+ * Class WPAdminSlugColumn
+ */
+class WPAdminSlugColumn {
 
 	/**
-	* Constructor for WPAdminSlugColumn Class
-	*/
+	 * Constructor for WPAdminSlugColumn Class
+	 */
 	public function __construct() {
-		add_action( 'current_screen',             array( $this, 'WPASC_post_type' ) );
-		add_filter( 'manage_posts_columns',       array( $this, 'WPASC_posts' ) );
-		add_action( 'manage_posts_custom_column', array( $this, 'WPASC_posts_data' ), 10, 2 );
-		add_filter( 'manage_pages_columns',       array( $this, 'WPASC_posts' ) );
-		add_action( 'manage_pages_custom_column', array( $this, 'WPASC_posts_data' ), 10, 2 );
+		add_action( 'current_screen', [ $this, 'init' ] );
 	}
 
 	/**
-	 * Returns an object that includes the current screen's post type
+	 * Initialize the plugin
 	 *
-	 * @see https://developer.wordpress.org/reference/functions/get_current_screen/
+	 * @param WP_Screen $current_screen The current screen object.
 	 */
-	public function WPASC_post_type() {
-		return get_current_screen()->post_type;
+	public function init( $current_screen ) {
+		if ( ! $current_screen->base === 'edit' ) {
+			return;
+		}
+
+		add_filter( "manage_{$current_screen->post_type}_posts_columns", [ $this, 'add_column' ] );
+		add_action( "manage_{$current_screen->post_type}_posts_custom_column", [ $this, 'display_column' ], 10, 2 );
 	}
 
 	/**
 	 * Adds Slug column to Posts list column
 	 *
-	 * @param array $defaults An array of column names
+	 * @param array $columns An array of column names.
+	 * @return array Modified array of column names.
 	 */
-	public function WPASC_posts( $defaults ) {
-		$defaults['wpasc-slug'] = __( 'URL Path', 'admin-slug-column' );
-		return $defaults;
+	public function add_column( $columns ) {
+		$columns['wpasc-slug'] = __( 'URL Path', 'admin-slug-column' );
+		return $columns;
 	}
 
 	/**
-	 * Gets the post info from get_post function and displays the slug and/or path
+	 * Displays the slug and/or path in the custom column
 	 *
-	 * @param string $column_name Name of the column
-	 * @param int    $id          post id
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/get_post/
+	 * @param string $column_name Name of the column.
+	 * @param int    $post_id     Post ID.
 	 */
-	public function WPASC_posts_data( $column_name, $id ) {
-		if ( $column_name == 'wpasc-slug' ) {
-			$post_info        = get_post( $id, 'string', 'display' );
-			$post_status      = $post_info->post_status;
-			$draft_slug_names = array( '%pagename%', '%postname%' );
+	public function display_column( $column_name, $post_id ) {
+		if ( 'wpasc-slug' !== $column_name ) {
+			return;
+		}
 
-			if ( 'draft' === $post_status || 'pending' === $post_status || 'future' === $post_status ) {
-				// unpublished status don't technically a slug yet so we have to use another function
-				$post_draft_url_array = get_sample_permalink( $id );
-				// grab the sample url path from the array and remove host and scheme
-				$post_draft_url_pre = str_replace( get_home_url(), '', $post_draft_url_array[0] );
-				// swap the draft %pagename% or %postname% holder with the sample permalink
-				$post_slug = str_replace( $draft_slug_names, $post_draft_url_array[1], $post_draft_url_pre );
-				// fyi: mb decoding is already done for us by the get_sample_permalink() array [1]
-				// now that we have the actual url path, because it's a draft lets make it gray
-				$post_slug = '<span style="color: #999;">' . $post_slug . '</span>';
-			} else {
-				// for published and everything else just use the post name and remove host and scheme
-				$post_slug = str_replace( get_home_url(), '', get_permalink( $id ) );
-				// decode for multibyte character support
-				$post_slug = esc_html( urldecode( $post_slug ) );
-			}
+		$post = get_post( $post_id );
+		$post_status = $post->post_status;
 
-			// output the slug
-			echo $post_slug;
+		if ( in_array( $post_status, [ 'draft', 'pending', 'future' ], true ) ) {
+			$this->display_draft_slug( $post_id );
+		} else {
+			$this->display_published_slug( $post_id );
 		}
 	}
 
+	/**
+	 * Displays the slug for draft, pending, or future posts
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function display_draft_slug( $post_id ) {
+		$post_draft_url_array = get_sample_permalink( $post_id );
+		$post_draft_url_pre = str_replace( home_url(), '', $post_draft_url_array[0] );
+		$post_slug = str_replace( [ '%pagename%', '%postname%' ], $post_draft_url_array[1], $post_draft_url_pre );
+		echo '<span style="color: #999;">' . esc_html( $post_slug ) . '</span>';
+	}
+
+	/**
+	 * Displays the slug for published posts
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function display_published_slug( $post_id ) {
+		$post_slug = str_replace( home_url(), '', get_permalink( $post_id ) );
+		echo esc_html( urldecode( $post_slug ) );
+	}
 }
 
-$WPAdminSlugColumn = new WPAdminSlugColumn();
+new WPAdminSlugColumn();

--- a/readme.txt
+++ b/readme.txt
@@ -32,12 +32,13 @@ Do you have a feature you'd like or a bug you've found? Feel free to [make an is
 
 Release Date - 2025-06-27
 
-* [refactor] Refactored to use dynamic hooks based on post type for proper CPT support
+* [refactor] Dynamic hooks based on post type for proper CPT support
 * [refactor] Column now inserts after "title" instead of appending to end
 * [refactor] Split display logic into separate private methods for draft and published posts
-* [security] Added output escaping and wp_strip_all_tags to all column output
+* [refactor] Pass WP_Post object through to avoid redundant get_post() calls per row
+* [security] Proper output escaping on all column output paths
 * [fix] Added WP_Post instanceof check and permalink string check before output
-* bump PHP requirement to 7.4
+* bump PHP requirement to 8.0
 
 = 1.6.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: ryno267
 Donate link: https://cash.me/$chuckreynolds
 Tags: slug, admin columns, permalink, url path, page titles
-Requires at least: 3.5
+Requires at least: 5.2
 Tested up to: 6.8.1
 Stable tag: 1.7.0
 License: GPLv2 or later
@@ -28,6 +28,17 @@ Do you have a feature you'd like or a bug you've found? Feel free to [make an is
 == Screenshots ==
 
 == Changelog ==
+= 1.7.0 =
+
+Release Date - 2025-06-27
+
+* [refactor] Refactored to use dynamic hooks based on post type for proper CPT support
+* [refactor] Column now inserts after "title" instead of appending to end
+* [refactor] Split display logic into separate private methods for draft and published posts
+* [security] Added output escaping and wp_strip_all_tags to all column output
+* [fix] Added WP_Post instanceof check and permalink string check before output
+* bump PHP requirement to 7.4
+
 = 1.6.1 =
 
 Release Date - 2024-09-19

--- a/readme.txt
+++ b/readme.txt
@@ -1,17 +1,17 @@
 === Admin Slug Column ===
 Contributors: ryno267
-Donate link: https://cash.me/$chuckreynolds
+Donate link: https://buymeacoffee.com/chuck
 Tags: slug, admin columns, permalink, url path, page titles
 Requires at least: 5.2
-Tested up to: 6.8.1
-Stable tag: 1.7.0
+Tested up to: 6.9.1
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Adds a column to admin posts/pages views showing the slug & URL path. Useful when titles are unclear or when many are too similar.
+Adds a URL path column to all admin post type edit screens. Works with posts, pages, and any custom post type including WooCommerce products.
 
 == Description ==
-This plugin adds a column to wp-admin "All Posts" and "All Pages" views displaying the URL path and Slug for each one. This will also show the nested path if a page is a child post of a parent. If a post or page is not published we'll do our best to determine the url path and display that slightly greyed out for quick reference as it's technically not an official URL path or Slug yet. This should also work for custom post types of type page or post, and furthermore this should now, as of v1.6, also display Multibyte characters in slugs for non-latin languages too.
+This plugin adds a URL path column to the edit screens for all post types — posts, pages, and any custom post type including WooCommerce products. Child pages show the full nested path. For drafts, pending, and scheduled content the URL path is shown slightly greyed out since it isn't an official URL yet. Multibyte characters in slugs (non-latin languages) are fully supported.
 
 I initially built this out of necessity to quickly identify pages by their slug/path as sometimes the titles that clients used did't match up nicely with the URL slug on the front-end of the site; so here's a fast way to do that. Nothing fancy, just does what it does.
 
@@ -28,17 +28,19 @@ Do you have a feature you'd like or a bug you've found? Feel free to [make an is
 == Screenshots ==
 
 == Changelog ==
-= 1.7.0 =
+= 2.0.0 =
 
-Release Date - 2025-06-27
+Release Date - 2026-03-09
 
-* [refactor] Dynamic hooks based on post type for proper CPT support
-* [refactor] Column now inserts after "title" instead of appending to end
-* [refactor] Split display logic into separate private methods for draft and published posts
-* [refactor] Pass WP_Post object through to avoid redundant get_post() calls per row
+* [breaking] PHP requirement bumped to 8.0
+* [refactor] Full OOP refactor — dynamic hooks based on current screen post type
+* [refactor] Column now inserts after "Title" instead of appending to end
+* [refactor] Split display logic into private methods for draft and published posts
 * [security] Proper output escaping on all column output paths
+* [fix] Draft slug now correctly resolves placeholder for any CPT rewrite tag, not just %postname%/%pagename%
 * [fix] Added WP_Post instanceof check and permalink string check before output
-* bump PHP requirement to 8.0
+* Confirmed working with custom post types and WooCommerce products
+* Tested up to WordPress 6.9.1
 
 = 1.6.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: ryno267
 Donate link: https://cash.me/$chuckreynolds
 Tags: slug, admin columns, permalink, url path, page titles
 Requires at least: 3.5
-Tested up to: 6.6.0
-Stable tag: 1.6.1
-License: GPL-2.0+
-License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+Tested up to: 6.8.1
+Stable tag: 1.7.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Adds a column to admin posts/pages views showing the slug & URL path. Useful when titles are unclear or when many are too similar.
 


### PR DESCRIPTION
## Summary
- Full OOP refactor: dynamic hooks based on `current_screen->post_type` replaces hardcoded post/page hooks, giving automatic support for all custom post types with no extra code
- Column now inserts after "Title" instead of appending at the end
- Split draft/published display logic into separate private methods
- Proper output escaping on all code paths
- PHP requirement bumped to 7.2 → 8.0
- Fix draft slug display for CPTs: `preg_replace('/%[^%]+%/')` replaces any rewrite tag placeholder, not just `%postname%`/`%pagename%` ....resolves WooCommerce products and other CPTs showing raw placeholder text on draft entries (closes #16)
- Updated readme: tested up to 6.9.1, updated descriptions

## Breaking changes
- Requires PHP 8.0+
- Column position changed (appended → after Title)
- Public method names changed (`WPASC_posts_data` etc. → `add_column`, `display_column`)

### Automate GH → WP plugin repo
- Adds GitHub Actions workflow that automatically deploys to WordPress.org SVN on every push to master via 10up/action-wordpress-plugin-deploy
- Adds .distignore to keep dev-only files out of SVN trunk (Readme.md, .github/, assets/, .claude/, etc.)
- Banner and icon images in assets/ are synced to SVN /assets/ separately