### PR TITLE
fix deploy workflow: trigger on version tags instead of branch push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy to WordPress.org
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   deploy:


### PR DESCRIPTION
10up/action-wordpress-plugin-deploy always attempts SVN tag creation which fails with a branch ref (refs/heads/master → invalid tag path). Trigger on semver tags instead which then also correctly creates the SVN tag that WordPress.org requires per release.

Release flow: merge to master then `git tag X.Y.Z && git push origin X.Y.Z`